### PR TITLE
Fixing squid:S1118 Utility classes should not have public constructors

### DIFF
--- a/app/src/main/java/com/haibuzou/datepicker/calendar/utils/DataUtils.java
+++ b/app/src/main/java/com/haibuzou/datepicker/calendar/utils/DataUtils.java
@@ -8,6 +8,7 @@ package com.haibuzou.datepicker.calendar.utils;
  * @author AigeStudio 2015-07-22
  */
 public final class DataUtils {
+    private DataUtils(){}
     /**
      * 一维数组转换为二维数组
      *

--- a/app/src/main/java/com/haibuzou/datepicker/calendar/utils/MeasureUtil.java
+++ b/app/src/main/java/com/haibuzou/datepicker/calendar/utils/MeasureUtil.java
@@ -10,6 +10,8 @@ import android.content.Context;
  * @author AigeStudio 2015-03-26
  */
 public final class MeasureUtil {
+    private MeasureUtil(){}
+
     public static int dp2px(Context context, float dp) {
         float scale = context.getResources().getDisplayMetrics().density;
         return (int) (dp * scale + 0.5f);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1118 - “Utility classes should not have public constructors ”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1118
 Please let me know if you have any questions.
Fevzi Ozgul
