### PR TITLE
Fixing multiple quality issues

### DIFF
--- a/app/src/main/java/com/haibuzou/datepicker/ScrollLayout.java
+++ b/app/src/main/java/com/haibuzou/datepicker/ScrollLayout.java
@@ -203,7 +203,6 @@ public class ScrollLayout extends FrameLayout implements MonthView.OnLineCountCh
     //重写 onMeasure 支持 wrap_content
     @Override
     protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
-        int widthMode = MeasureSpec.getMode(widthMeasureSpec);
         int widthSize = MeasureSpec.getSize(widthMeasureSpec);
         int heightMode = MeasureSpec.getMode(heightMeasureSpec);
         int heightSize = MeasureSpec.getSize(heightMeasureSpec);

--- a/app/src/main/java/com/haibuzou/datepicker/calendar/bizs/calendars/SolarTerm.java
+++ b/app/src/main/java/com/haibuzou/datepicker/calendar/bizs/calendars/SolarTerm.java
@@ -123,11 +123,9 @@ final class SolarTerm {
         this.D = D - int2(m * 30.6001);
         y -= 4716;
         m--;
-        if (m > 12)
+        if (m > 12){
             m -= 12;
-        if (m <= 2)
-            //noinspection UnusedAssignment
-            y++;
+        }
     }
 
     private double int2(double v) {

--- a/app/src/main/java/com/haibuzou/datepicker/calendar/views/MonthView.java
+++ b/app/src/main/java/com/haibuzou/datepicker/calendar/views/MonthView.java
@@ -358,13 +358,15 @@ public class MonthView extends View {
 
 	private void drawBGCircle(Canvas canvas) {
 		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
-			for (String s : cirDpr.keySet()) {
-				BGCircle circle = cirDpr.get(s);
+			for (Map.Entry<String,BGCircle> entry: cirDpr.entrySet()) {
+				String key=entry.getKey();
+				BGCircle circle = entry.getValue();
 				drawBGCircle(canvas, circle);
 			}
 		}
-		for (String s : cirApr.keySet()) {
-			BGCircle circle = cirApr.get(s);
+		for (Map.Entry<String,BGCircle> entry: cirDpr.entrySet()) {
+			String key=entry.getKey();
+			BGCircle circle = entry.getValue();
 			drawBGCircle(canvas, circle);
 		}
 	}

--- a/app/src/main/java/com/haibuzou/datepicker/calendar/views/WeekView.java
+++ b/app/src/main/java/com/haibuzou/datepicker/calendar/views/WeekView.java
@@ -334,13 +334,15 @@ public class WeekView extends View {
 
 	private void drawBGCircle(Canvas canvas) {
 		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
-			for (String s : cirDpr.keySet()) {
-				BGCircle circle = cirDpr.get(s);
+			for (Map.Entry<String,BGCircle> entry: cirDpr.entrySet()) {
+				String key=entry.getKey();
+				BGCircle circle = entry.getValue();
 				drawBGCircle(canvas, circle);
 			}
 		}
-		for (String s : cirApr.keySet()) {
-			BGCircle circle = cirApr.get(s);
+		for (Map.Entry<String,BGCircle> entry: cirDpr.entrySet()) {
+			String key=entry.getKey();
+			BGCircle circle = entry.getValue();
 			drawBGCircle(canvas, circle);
 		}
 	}


### PR DESCRIPTION
"This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1854 - “ Dead stores should be removed ”. 
and squid: S2864 "entrySet()" should be iterated when both the key and value are needed
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1854
https://dev.eclipse.org/sonar/rules/show/squid:S2864
 Please let me know if you have any questions.
 Fevzi Ozgul
